### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,6 +6,7 @@ services:
     buildCommand: yarn install && yarn build
     startCommand: yarn start
     healthCheckPath: /_health
+    autoDeploy: false
     envVars:
       - key: NODE_VERSION
         value: ~16.13.0


### PR DESCRIPTION
By setting autoDeploy: false in the the render.yaml, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See https://render.com/docs/deploy-to-render for more information.

Signed-off-by: zach wick <zach@render.com>