### PR TITLE
Update strapi and add new keys needed

### DIFF
--- a/config/admin.js
+++ b/config/admin.js
@@ -2,4 +2,7 @@ module.exports = ({ env }) => ({
   auth: {
     secret: env('ADMIN_JWT_SECRET'),
   },
+  apiToken: {
+    salt: env('API_TOKEN_SALT'),
+  },
 });

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "@strapi/strapi": "4.1.7",
-    "@strapi/plugin-users-permissions": "4.1.7",
-    "@strapi/plugin-i18n": "4.1.7",
-    "@strapi/provider-upload-cloudinary": "4.1.7",
+    "@strapi/strapi": "4.13.3",
+    "@strapi/plugin-users-permissions": "4.13.3",
+    "@strapi/plugin-i18n": "4.13.3",
+    "@strapi/provider-upload-cloudinary": "4.13.3",
+    "better-sqlite3": "7.4.6",
     "pg": "^8.7.0",
     "pg-connection-string": "^2.5.0",
     "sqlite3": "latest"

--- a/render.yaml
+++ b/render.yaml
@@ -26,6 +26,8 @@ services:
         generateValue: true
       - key: ADMIN_JWT_SECRET
         generateValue: true
+      - key: API_TOKEN_SALT
+        generateValue: true
       - key: APP_KEYS
         generateValue: true
 


### PR DESCRIPTION
Based on guidelines of [updating strapi](https://docs.strapi.io/dev-docs/update-version) and the [latest release](https://github.com/strapi/strapi/releases/tag/v4.13.3) of it.

I updated:
- `config/admin.js` to contain the new required key for strapi.
- `package.json` to use new versions of strapi.
- `render.yaml` to require the automatic generation of the new key.

